### PR TITLE
vm3: fix bus address multiplexer for data transactions

### DIFF
--- a/vm3/hdl/wbc/rtl/vm3_wb.v
+++ b/vm3/hdl/wbc/rtl/vm3_wb.v
@@ -2284,7 +2284,7 @@ assign sx_ro = op1_wf & ~mmu_d[2] & mmu_d[1];            // readonly error
 assign sx_nr = ~mmu_d[1] | (mt_mod[5] ^ mt_mod[6]);      // not resident or bad mode
 
 assign a0_reg = ba_fsel ? ba_fr[0] : ba_ax[0];
-assign ba = (ba_pca | ba_pca_rc) ? pca : (ba_fsel ? ba_fr : ba_ax);
+assign ba = (ba_pca | (ba_pca_rc & ~sa_sxa)) ? pca : (ba_fsel ? ba_fr : ba_ax);
 assign sa77 = ba[15:13] == 3'b111;
 
 assign bs_a22 = (as[21:13] == 9'o777);


### PR DESCRIPTION
There are two kinds of bus transactions - data exchange and instruction prefetch. The address multiplexer provided the wrong data address, the prefetch address was provided if the data/prefetch cycle was interleaved with internal register access (MMU/PSW).

The test program to catch:

	.title	vm3bug
	.asect
	. = 0
	jmp	@#start
	. = 24
	.word	start
	.word	340
start:	mov	#172342, R0
	mov	@R0, @#100
	clr	@R0
	nop
	nop
	halt
	halt

The writing to address @#100 actually occured to @#42 - the address of the next instruction being prefetched.

Reported-by: forth32 user @ zx-pk.ru